### PR TITLE
Add `MemoryStream.Truncate()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Add `MemoryStream.Truncate()`
+
 ## [0.1.0] - 2019-11-07
 
 - Initial release

--- a/ordered/stream_test.go
+++ b/ordered/stream_test.go
@@ -145,6 +145,71 @@ var _ = Describe("type MemoryStream", func() {
 		})
 	})
 
+	Describe("func Truncate()", func() {
+		It("truncates events before the given offset", func() {
+			stream.Truncate(2)
+
+			cur, err := stream.Open(ctx, 1, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			_, err = cur.Next(ctx)
+			Expect(err).To(MatchError("can not read truncated event at offset 1, the first available offset is 2"))
+		})
+
+		It("does not truncate events after the given offset", func() {
+			stream.Truncate(2)
+
+			cur, err := stream.Open(ctx, 2, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			env, err := cur.Next(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(env).To(Equal(
+				Envelope{
+					2,
+					now,
+					MessageA2,
+				},
+			))
+
+			env, err = cur.Next(ctx)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(env).To(Equal(
+				Envelope{
+					3,
+					now,
+					MessageB2,
+				},
+			))
+		})
+
+		It("returns the number of truncated events", func() {
+			n := stream.Truncate(2)
+			Expect(n).To(BeNumerically("==", 2))
+			n = stream.Truncate(3)
+			Expect(n).To(BeNumerically("==", 1))
+		})
+
+		It("does not truncate any events if they have already been truncated", func() {
+			n := stream.Truncate(2)
+			Expect(n).To(BeNumerically("==", 2))
+			n = stream.Truncate(2)
+			Expect(n).To(BeNumerically("==", 0))
+		})
+
+		It("allows truncation up to the next offset", func() {
+			Expect(func() {
+				stream.Truncate(4)
+			}).NotTo(Panic())
+		})
+
+		It("panics if the offset is greater than the total number of events", func() {
+			Expect(func() {
+				stream.Truncate(5)
+			}).To(Panic())
+		})
+	})
+
 	Describe("type memoryCursor", func() {
 		Describe("func Next()", func() {
 			It("returns an error if the cursor is already closed", func() {


### PR DESCRIPTION
This PR adds a `Truncate()` method which removes messages from the beginning of the stream. This is primarily to allow for the purging on unnecessary messages from memory.