### PR TITLE
Add low-level resource API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,33 +9,39 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Add `ordered/resource` package for low-level OCC resource manipulation
+
 ## [0.3.0] - 2020-01-30
 
-## Changed
+### Changed
 
 - **[BC]** Update to `dogmatiq/configkit` v0.3.0
 
 ## [0.2.2] - 2020-01-23
 
-## Fixed
+### Fixed
 
 - Fix collision between `dogma.handler.type` and `dogma.message.role` tracing attributes
 
 ## [0.2.1] - 2020-01-16
 
-## Added
+### Added
 
 - Add `ordered.ErrStreamSealed`
 - Add `MemoryStream.Seal()`
 
-## Changed
+### Changed
 
 - `Stream.Open()` and `Cursor.Next()` may now return `ErrStreamSealed`
 - `MemoryStream.ID()` now panics if the `StreamID` field is empty
 - `MemoryStream.Append()` now panics if `Seal()` has been called
 - `MemoryStream.Append()` now panics if any of the given messages is `nil`
 
-## Fixed
+### Fixed
 
 - Fix unconditional OCC failure in `ordered.Projector`
 

--- a/ordered/projector_test.go
+++ b/ordered/projector_test.go
@@ -361,7 +361,7 @@ var _ = Describe("type Projector", func() {
 
 				err := proj.Run(ctx)
 				Expect(err).To(MatchError(
-					"unable to consume from '<id>' for the '<proj>' projection: the persisted version is 1 byte(s), expected 0 or 8",
+					"unable to consume from '<id>' for the '<proj>' projection: version is 1 byte(s), expected 0 or 8",
 				))
 			})
 

--- a/ordered/resource/doc.go
+++ b/ordered/resource/doc.go
@@ -1,0 +1,3 @@
+// Package resource contains utilities for performing low-level manipulations of
+// projection resource versions.
+package resource

--- a/ordered/resource/gingko_test.go
+++ b/ordered/resource/gingko_test.go
@@ -1,0 +1,15 @@
+package resource_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	type tag struct{}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, reflect.TypeOf(tag{}).PkgPath())
+}

--- a/ordered/resource/resource.go
+++ b/ordered/resource/resource.go
@@ -1,0 +1,54 @@
+package resource
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// FromStreamID returns the resource to use for the given stream ID.
+func FromStreamID(id string) []byte {
+	return []byte(id)
+}
+
+// MarshalOffset marshals a stream offset to a resource version.
+//
+// o is the next offset to be read from the stream, not the last offset
+// that was applied to the projection.
+func MarshalOffset(o uint64) []byte {
+	return MarshalOffsetInto(make([]byte, 8), o)
+}
+
+// MarshalOffsetInto marshals a stream offset using the memory of an existing
+// buffer.
+//
+// buf is the buffer to use, it must be at least 8 bytes in length.
+//
+// o is the next offset to be read from the stream, not the last offset that was
+// applied to the projection.
+func MarshalOffsetInto(buf []byte, o uint64) []byte {
+	if o == 0 {
+		return buf[:0]
+	}
+
+	binary.BigEndian.PutUint64(buf, o-1)
+
+	return buf[:8]
+}
+
+// UnmarshalOffset unmarshals a stream offset from a resource version.
+//
+// It returns the next offset to be read from the stream, not the last offset
+// that was applied to the projection.
+func UnmarshalOffset(v []byte) (uint64, error) {
+	switch len(v) {
+	case 0:
+		return 0, nil
+	case 8:
+		return binary.BigEndian.Uint64(v) + 1, nil
+	default:
+		return 0, fmt.Errorf(
+			"version is %d byte(s), expected 0 or 8",
+			len(v),
+		)
+	}
+}

--- a/ordered/resource/resource_test.go
+++ b/ordered/resource/resource_test.go
@@ -1,0 +1,97 @@
+package resource_test
+
+import (
+	. "github.com/dogmatiq/aperture/ordered/resource"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("func FromStreamID()", func() {
+	It("returns the stream ID as a byte-slice", func() {
+		r := FromStreamID("<id>")
+		Expect(r).To(Equal([]byte("<id>")))
+	})
+})
+
+var _ = Describe("func MarshalOffset()", func() {
+	It("returns an empty slice for the zero offset", func() {
+		v := MarshalOffset(0)
+		Expect(v).To(BeEmpty())
+	})
+
+	It("returns the previous offset as a big-endian uint64", func() {
+		v := MarshalOffset(0x0102030405060708)
+
+		Expect(v).To(Equal(
+			[]byte{
+				0x01,
+				0x02,
+				0x03,
+				0x04,
+				0x05,
+				0x06,
+				0x07,
+				0x07, // v - 1
+			},
+		))
+	})
+})
+
+var _ = Describe("func MarshalOffsetInto()", func() {
+	buf := make([]byte, 10) // longer than needed
+
+	It("returns an empty slice for the zero offset", func() {
+		v := MarshalOffsetInto(buf, 0)
+		Expect(v).To(BeEmpty())
+	})
+
+	It("returns the previous offset as a big-endian uint64", func() {
+		v := MarshalOffsetInto(buf, 0x0102030405060708)
+
+		Expect(buf[:8]).To(Equal(v))
+		Expect(v).To(Equal(
+			[]byte{
+				0x01,
+				0x02,
+				0x03,
+				0x04,
+				0x05,
+				0x06,
+				0x07,
+				0x07, // v - 1
+			},
+		))
+	})
+})
+
+var _ = Describe("func UnmarshalOffsetInto()", func() {
+	It("returns zero if the buffer is empty", func() {
+		o, err := UnmarshalOffset(nil)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(o).To(BeNumerically("==", 0))
+
+		o, err = UnmarshalOffset([]byte{})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(o).To(BeNumerically("==", 0))
+	})
+
+	It("returns the next offset", func() {
+		o, err := UnmarshalOffset([]byte{
+			0x01,
+			0x02,
+			0x03,
+			0x04,
+			0x05,
+			0x06,
+			0x07,
+			0x07, // o - 1
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(o).To(BeNumerically("==", 0x0102030405060708))
+	})
+
+	It("returns an error if the byte-slice is an unexpected length", func() {
+		_, err := UnmarshalOffset([]byte{0})
+		Expect(err).To(MatchError("version is 1 byte(s), expected 0 or 8"))
+	})
+})


### PR DESCRIPTION
This PR is a companion to https://github.com/dogmatiq/projectionkit/pull/28, that exposes the specifics of how aperture uses resource versions to encode stream offsets.